### PR TITLE
Fix Unbound Reference Warning

### DIFF
--- a/ch.netcetera.eclipse.projectconfig.core/OSGI-INF/ProjectCofigurationService.xml
+++ b/ch.netcetera.eclipse.projectconfig.core/OSGI-INF/ProjectCofigurationService.xml
@@ -4,5 +4,5 @@
    <service>
       <provide interface="ch.netcetera.eclipse.projectconfig.core.IProjectConfigurationService"/>
    </service>
-   <reference bind="bindClient" cardinality="1..1" interface="ch.netcetera.eclipse.projectconfig.net.IProjectConfigurationClient" name="IProjectConfigurationClient" policy="static" unbind="unbindClient"/>
+   <reference bind="bindClient" cardinality="1..1" interface="ch.netcetera.eclipse.projectconfig.net.IProjectConfigurationClient" name="IProjectConfigurationClient" policy="dynamic" unbind="unbindClient"/>
 </scr:component>

--- a/ch.netcetera.eclipse.projectconfig.net/OSGI-INF/ProjectConfigurationClient.xml
+++ b/ch.netcetera.eclipse.projectconfig.net/OSGI-INF/ProjectConfigurationClient.xml
@@ -4,5 +4,5 @@
    <service>
       <provide interface="ch.netcetera.eclipse.projectconfig.net.IProjectConfigurationClient"/>
    </service>
-   <reference bind="bindProxyService" cardinality="0..1" interface="org.eclipse.core.net.proxy.IProxyService" name="IProxyService" policy="dynamic" unbind="unbindProxyService"/>
+   <reference bind="bindProxyService" cardinality="1..1" interface="org.eclipse.core.net.proxy.IProxyService" name="IProxyService" policy="dynamic" unbind="unbindProxyService"/>
 </scr:component>

--- a/ch.netcetera.eclipse.projectconfig.ui/src/ch/netcetera/eclipse/projectconfig/ui/ProjectConfigurationUIPlugin.java
+++ b/ch.netcetera.eclipse.projectconfig.ui/src/ch/netcetera/eclipse/projectconfig/ui/ProjectConfigurationUIPlugin.java
@@ -37,8 +37,7 @@ public class ProjectConfigurationUIPlugin extends AbstractTextAccessorUIPlugin {
 
   private static ProjectConfigurationUIPlugin plugin;
 
-  private ServiceTracker<IProjectConfigurationService, Object> tracker;
-  private IProjectConfigurationService service;
+  private ServiceTracker<?, IProjectConfigurationService> tracker;
 
 
 
@@ -48,10 +47,9 @@ public class ProjectConfigurationUIPlugin extends AbstractTextAccessorUIPlugin {
     super.start(context);
     plugin = this;
 
-    this.tracker = new ServiceTracker<IProjectConfigurationService, Object>(context,
+    this.tracker = new ServiceTracker<IProjectConfigurationService, IProjectConfigurationService>(context,
         IProjectConfigurationService.class.getName(), null);
     this.tracker.open();
-    this.service = (IProjectConfigurationService) this.tracker.getService();
   }
 
   /** {@inheritDoc} */
@@ -83,6 +81,6 @@ public class ProjectConfigurationUIPlugin extends AbstractTextAccessorUIPlugin {
    * @return the {@link IProjectConfigurationService} instance
    */
   public IProjectConfigurationService getProjectConfigurationService() {
-    return this.service;
+    return this.tracker.getService();
   }
 }

--- a/ch.netcetera.eclipse.workspaceconfig.net/OSGI-INF/WorkspacePreferenceClient.xml
+++ b/ch.netcetera.eclipse.workspaceconfig.net/OSGI-INF/WorkspacePreferenceClient.xml
@@ -4,5 +4,5 @@
    <service>
       <provide interface="ch.netcetera.eclipse.workspaceconfig.net.IWorkspacePreferenceClient"/>
    </service>
-   <reference bind="bindProxyService" cardinality="0..1" interface="org.eclipse.core.net.proxy.IProxyService" name="IProxyService" policy="dynamic" unbind="unbindProxyService"/>
+   <reference bind="bindProxyService" cardinality="1..1" interface="org.eclipse.core.net.proxy.IProxyService" name="IProxyService" policy="dynamic" unbind="unbindProxyService"/>
 </scr:component>


### PR DESCRIPTION
When starting you get the warning

```
    Could not bind a reference of component
ch.netcetera.eclipse.projectconfig.net.client. The reference is:
Reference[name = IProxyService, interface =
org.eclipse.core.net.proxy.IProxyService, policy = dynamic, cardinality
= 0..1, target = null, bind = bindProxyService, unbind =
unbindProxyService]
```
- change the cardinality of the proxy service
- get the `IProjectConfigurationService` lazy
- make the `IProjectConfigurationClient` reference dynamic

Fixes #13
